### PR TITLE
Create bananaci command

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,6 +2,30 @@
 
 
 [[projects]]
+  digest = "1:870d441fe217b8e689d7949fef6e43efbc787e50f200cb1e70dbca9204a1d6be"
+  name = "github.com/inconshreveable/mousetrap"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75"
+  version = "v1.0"
+
+[[projects]]
+  digest = "1:645cabccbb4fa8aab25a956cbcbdf6a6845ca736b2c64e197ca7cbb9d210b939"
+  name = "github.com/spf13/cobra"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "ef82de70bb3f60c65fb8eebacbb2d122ef517385"
+  version = "v0.0.3"
+
+[[projects]]
+  digest = "1:c1b1102241e7f645bc8e0c22ae352e8f0dc6484b6cb4d132fa9f24174e0119e2"
+  name = "github.com/spf13/pflag"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "298182f68c66c05229eb03ac171abe6e309ee79a"
+  version = "v1.0.3"
+
+[[projects]]
   digest = "1:4d2e5a73dc1500038e504a8d78b986630e3626dc027bc030ba5c75da257cdb96"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
@@ -12,6 +36,9 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  input-imports = ["gopkg.in/yaml.v2"]
+  input-imports = [
+    "github.com/spf13/cobra",
+    "gopkg.in/yaml.v2",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -1,0 +1,21 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "bananaci",
+	Short: "BananaCI is multi stage generator",
+	Long:  `This is Log Description.`,
+}
+
+func Execute() {
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -1,0 +1,53 @@
+package cmd
+
+import (
+	"sync"
+
+	"github.com/spf13/cobra"
+	jobQueue "github.com/tkhr0/bananaci-prototype/lib/job_queue"
+	"github.com/tkhr0/bananaci-prototype/lib/server"
+)
+
+// serverCmd represents the server command
+var serverCmd = &cobra.Command{
+	Use:   "server",
+	Short: "Run BananaCI server.",
+	Long:  `Run worker and http server.`,
+	Run:   serverCmdMain,
+}
+
+func init() {
+	rootCmd.AddCommand(serverCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// serverCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// serverCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}
+
+func serverCmdMain(cmd *cobra.Command, args []string) {
+	maxWorkers := 3
+	maxQueues := 10000
+	d := jobQueue.NewDispatcher(maxWorkers, maxQueues)
+
+	wg := &sync.WaitGroup{}
+
+	wg.Add(1)
+	go func() {
+		server.Call(d)
+		wg.Done()
+	}()
+
+	wg.Add(1)
+	go func() {
+		server.CallHTTP(d)
+		wg.Done()
+	}()
+
+	wg.Wait()
+}

--- a/main.go
+++ b/main.go
@@ -1,30 +1,9 @@
 package main
 
 import (
-	"sync"
-
-	jobQueue "github.com/tkhr0/bananaci-prototype/lib/job_queue"
-	"github.com/tkhr0/bananaci-prototype/lib/server"
+	"github.com/tkhr0/bananaci-prototype/cmd"
 )
 
 func main() {
-	maxWorkers := 3
-	maxQueues := 10000
-	d := jobQueue.NewDispatcher(maxWorkers, maxQueues)
-
-	wg := &sync.WaitGroup{}
-
-	wg.Add(1)
-	go func() {
-		server.Call(d)
-		wg.Done()
-	}()
-
-	wg.Add(1)
-	go func() {
-		server.CallHTTP(d)
-		wg.Done()
-	}()
-
-	wg.Wait()
+	cmd.Execute()
 }


### PR DESCRIPTION
- install [spf13/cobra: A Commander for modern Go CLI interactions](https://github.com/spf13/cobra)
  because it be used by kubernetes

ビルドテストのために command line interface が欲しくて追加。
なので、既存の処理はコマンド配下に移行しただけ（オプションとか整えてない）。